### PR TITLE
Adds DSL/CVX indentation examples.

### DIFF
--- a/tests/style/dsl/cvx/001.m
+++ b/tests/style/dsl/cvx/001.m
@@ -1,0 +1,10 @@
+cvx_begin sdp
+    variable X( n, n ) symmetric
+    dual variable y{n}
+    dual variable Z
+    minimize((n - 1:-1:0) * diag(X))
+    for k = 1:n
+        sum(diag(X, k - 1)) == b(k):y{k};
+    end
+    X >= 0:Z;
+cvx_end

--- a/tests/style/dsl/cvx/002.m
+++ b/tests/style/dsl/cvx/002.m
@@ -1,0 +1,4 @@
+cvx_begin quiet
+    variable x(n)
+    minimize(norm(A * x - b, 1) + gamma(k) * norm(x, Inf))
+cvx_end

--- a/tests/style/dsl/cvx/003.m
+++ b/tests/style/dsl/cvx/003.m
@@ -1,0 +1,8 @@
+cvx_begin
+    variable x(n)
+    dual variables y z
+    minimize(c' * x + d)
+    subject to
+        y:A * x == b;
+        z:x >= 0;
+cvx_end

--- a/tests/style/dsl/cvx/004.m
+++ b/tests/style/dsl/cvx/004.m
@@ -1,0 +1,7 @@
+cvx_begin
+    variable x(n)
+    dual variables y z
+    minimize(c' * x + d)
+    subject to
+        y:A * x <= b;
+cvx_end

--- a/tests/style/dsl/cvx/005.m
+++ b/tests/style/dsl/cvx/005.m
@@ -1,0 +1,4 @@
+cvx_begin
+    variable x(n)
+    minimize(norm(A * x - b))
+cvx_end

--- a/tests/style/dsl/cvx/006.m
+++ b/tests/style/dsl/cvx/006.m
@@ -1,0 +1,7 @@
+cvx_begin
+    variable x(n)
+    dual variable y
+    minimize(norm(A * x - b, p))
+    subject to
+        y:C * x == d;
+cvx_end

--- a/tests/style/dsl/cvx/007.m
+++ b/tests/style/dsl/cvx/007.m
@@ -1,0 +1,10 @@
+cvx_begin quiet
+    if mod(iter, 2) == 1
+        variable X(k,n)
+        X >= 0;
+    else
+        variable Y(m,k)
+        Y >= 0;
+    end
+    minimize(norm(A - Y * X, 'fro'))
+cvx_end

--- a/tests/style/dsl/cvx/008.m
+++ b/tests/style/dsl/cvx/008.m
@@ -1,0 +1,37 @@
+cvx_begin
+    variable x(n)
+    minimize(norm(A * x - b))
+cvx_end
+cvx_begin
+    variable x(n)
+    minimize(norm(A * x - b))
+    subject to
+        l <= x <= u;
+cvx_end
+cvx_begin
+    variable x(n)
+    minimize(norm(A * x - b, Inf))
+cvx_end
+cvx_begin
+    variable x(n)
+    minimize(norm(A * x - b, 1))
+cvx_end
+cvx_begin
+    variable x(n)
+    minimize(norm_largest(A * x - b, k))
+cvx_end
+cvx_begin
+    variable x(n)
+    minimize(sum(huber(A * x - b)))
+cvx_end
+cvx_begin
+    variable x(n)
+    minimize(norm(A * x - b))
+    subject to
+        C * x == d;
+        norm(x, Inf) <= 1;
+cvx_end
+cvx_begin
+    variable x(n)
+    minimize(norm(A * x - b) + gamma(k) * norm(x, 1))
+cvx_end

--- a/tests/style/dsl/cvx/009.m
+++ b/tests/style/dsl/cvx/009.m
@@ -1,0 +1,6 @@
+cvx_begin sdp
+    variable Z(n,n) hermitian toeplitz
+    dual variable Q
+    minimize(norm(Z - P, 'fro'))
+    Z >= 0:Q;
+cvx_end

--- a/tests/style/dsl/cvx/010.m
+++ b/tests/style/dsl/cvx/010.m
@@ -1,0 +1,12 @@
+cvx_begin sdp quiet
+    variable x(m)
+    variable G(n,n) symmetric
+    variable C(n,n) symmetric
+    minimize(L' * x)
+    G == reshape(GG * [1; x], n, n);
+    C == reshape(CC * [1; x], n, n);
+    for k = 1:n
+        delay * G - C + sparse(k, k, delay, n, n) >= 0;
+    end
+    0 <= x <= wmax;
+cvx_end

--- a/tests/style/dsl/cvx/011.m
+++ b/tests/style/dsl/cvx/011.m
@@ -1,0 +1,10 @@
+cvx_begin sdp quiet
+    variable x(m)
+    variable G(n,n) symmetric
+    variable C(n,n) symmetric
+    minimize(sum(x))
+    G == reshape(GG * [1; x], n, n);
+    C == reshape(CC * [1; x], n, n);
+    delay * G - C >= 0;
+    0 <= x <= wmax;
+cvx_end

--- a/tests/style/dsl/cvx/012.m
+++ b/tests/style/dsl/cvx/012.m
@@ -1,0 +1,60 @@
+cvx_begin gp quiet
+    if need_sedumi
+        cvx_solver sedumi
+    end
+    
+    % device width variables
+    variable w(N)
+    
+    % device specs
+    device(1:2) = PMOS;
+    device(3:4) = NMOS;
+    
+    for num = 1:N
+        device(num).R   = device(num).R / w(num);
+        device(num).Cdb = device(num).Cdb * w(num);
+        device(num).Csb = device(num).Csb * w(num);
+        device(num).Cgb = device(num).Cgb * w(num);
+        device(num).Cgs = device(num).Cgs * w(num);
+    end
+    
+    % capacitances
+    C1 = sum([device(1:3).Cdb]) + Cload;
+    C2 = device(3).Csb + device(4).Cdb;
+    
+    % input capacitances
+    Cin_A = sum([device([2 3]).Cgb]) + sum([device([2 3]).Cgs]);
+    Cin_B = sum([device([1 4]).Cgb]) + sum([device([1 4]).Cgs]);
+    
+    % resistances
+    R = [device.R]';
+    
+    % area definition
+    area = sum(w);
+    
+    % delays and dissipated energies for all six possible transitions
+    % transition 1 is A: 1->1, B: 1->0, Z: 0->1
+    D1 = R(1) * (C1 + C2);
+    E1 = (C1 + C2) * Vdd^2 / 2;
+    % transition 2 is A: 1->0, B: 1->1, Z: 0->1
+    D2 = R(2) * C1;
+    E2 = C1 * Vdd^2 / 2;
+    % transition 3 is A: 1->0, B: 1->0, Z: 0->1
+    % D3 = C1*R(1)*R(2)/(R(1) + R(2)); % not a posynomial
+    E3 = C1 * Vdd^2 / 2;
+    % transition 4 is A: 1->1, B: 0->1, Z: 1->0
+    D4 = C1 * R(3) + R(4) * (C1 + C2);
+    E4 = (C1 + C2) * Vdd^2 / 2;
+    % transition 5 is A: 0->1, B: 1->1, Z: 1->0
+    D5 = C1 * (R(3) + R(4));
+    E5 = (C1 + C2) * Vdd^2 / 2;
+    % transition 6 is A: 0->1, B: 0->1, Z: 1->0
+    D6 = C1 * R(3) + R(4) * (C1 + C2);
+    E6 = (C1 + C2) * Vdd^2 / 2;
+    
+    % objective is the worst-case delay
+    minimize(max([D1 D2 D4]))
+    subject to
+        area <= Amax(k);
+        w >= wmin;
+cvx_end

--- a/tests/style/dsl/cvx/013.m
+++ b/tests/style/dsl/cvx/013.m
@@ -1,0 +1,49 @@
+cvx_begin gp quiet
+    % optimization variables
+    variable w(N-1)     % wire width
+    variable T(N)       % arrival time (Elmore delay to node i)
+    
+    % objective is the critical Elmore delay
+    minimize(max(T(leafs)))
+    subject to
+        
+        % wire segment resistance is inversely proportional to widths
+        R = alpha .* l ./ w;
+        R = [Rsource; R];
+        
+        % wire segment capacitance is an affine function of widths
+        C_bar = beta .* l .* w + gamma .* l;
+        C_bar = [0; C_bar];
+        
+        % compute common capacitances for each node (C_tilde in GP tutorial)
+        C_tilde = cvx(zeros(N, 1));
+        for node = [1:N]
+            C_tilde(node, 1) = Cload(node);
+            for k = parent(node)
+                if k > 0
+                    C_tilde(node, 1) = C_tilde(node, 1) + C_bar(k);
+                end
+            end
+            for k = children{node}
+                C_tilde(node, 1) = C_tilde(node, 1) + C_bar(k);
+            end
+        end
+        
+        % now compute total downstream capacitances
+        C_total = C_tilde;
+        for node = N:-1:1
+            for k = children{node}
+                C_total(node, 1) = C_total(node, 1) + C_total(k, 1);
+            end
+        end
+        
+        % generate Elmore delay constraints
+        R(1) * C_total(1) <= T(1, 1);
+        for node = 2:N
+            R(node) * C_total(node) + T(parent(node), 1) <= T(node, 1);
+        end
+        
+        % collect all the constraints
+        sum(w .* l) <= Amax;
+        Wmin <= w <= Wmax;
+cvx_end

--- a/tests/style/dsl/cvx/014.m
+++ b/tests/style/dsl/cvx/014.m
@@ -1,0 +1,12 @@
+cvx_begin sdp quiet
+    variable x(m)
+    variable G(n,n) symmetric
+    variable C(n,n) symmetric
+    dual variables Y1 Y2 Y3 Y4 Y5
+    minimize(sum(C(:)))
+    subject to
+        G == reshape(GG * [1; x], n, n);
+        C == reshape(CC * [1; x], n, n);
+        delay * G - C >= 0;
+        0 <= x <= wmax;
+cvx_end

--- a/tests/style/dsl/cvx/015.m
+++ b/tests/style/dsl/cvx/015.m
@@ -1,0 +1,12 @@
+cvx_begin sdp quiet
+    variables w(m,2) d(1,2)
+    variable G(n,n,2) symmetric
+    variable C(n,n,2) symmetric
+    minimize(L * sum(d) + sum(w(:)))
+    G == reshape(GG * [1; w(:); d(:)], n, n, 2);
+    C == reshape(CC * [1; w(:); d(:)], n, n, 2);
+    % This is actually two LMIs, one for each circuit
+    (delay / 2) * G - C >= 0;
+    0 <= w(:) <= wmax;
+    d(:) >= 0;
+cvx_end

--- a/tests/style/dsl/cvx/016.m
+++ b/tests/style/dsl/cvx/016.m
@@ -1,0 +1,54 @@
+cvx_begin gp quiet
+    % optimization variables
+    variable x(m)                 % scale factor
+    variable T(m)                 % arrival times
+    
+    % input capacitance is an affine function of sizes
+    Cin  = Cin_norm .* x;
+    Cint = Cint_norm .* x;
+    
+    % driving resistance is inversily proportional to sizes
+    R = Rdrv_norm ./ x;
+    
+    % gate delay is the product of its driving resistance and load cap.
+    Cload = cvx(zeros(m, 1));
+    for gate = 1:m
+        if ~ismember(FO{gate}, primary_outputs)
+            Cload(gate) = sum(Cin(FO{gate}));
+        else
+            Cload(gate) = Cin_po(FO{gate});
+        end
+    end
+    
+    % delay
+    D = 0.69 * ones(m, 1) .* R .* (Cint + Cload);
+    
+    % total area
+    area = A_norm' * x;
+    
+    % total power calculation
+    Pdyn = Vdd^2 * sum(f_pi(primary_inputs) .* Cload_pi(primary_inputs)) + ...
+    Vdd^2 * (f_gates' * (Cint + Cload));
+    Pstat = Vdd * Ileak_norm' * x;
+    power = Pdyn + Pstat;
+    
+    minimize(max(T(output_gates)))
+    subject to
+        % constraints
+        x >= 1;
+        area <= Amax;
+        power <= Pmax(n);
+        
+        % create timing constraints
+        for gate = 1:m
+            if ~ismember(FI{gate}, primary_inputs)
+                for j = FI{gate}
+                    % enforce T_j + D_j <= T_i over all gates j that drive i
+                    D(gate) + T(j) <= T(gate);
+                end
+            else
+                % enforce D_i <= T_i for gates i connected to primary inputs
+                D(gate) <= T(gate);
+            end
+        end
+cvx_end

--- a/tests/style/dsl/cvx/017.m
+++ b/tests/style/dsl/cvx/017.m
@@ -1,0 +1,50 @@
+cvx_begin gp
+    % optimization variables
+    variable x(N)                 % sizes
+    variable T(N)                 % arrival times
+    
+    % minimize the sum of scale factors subject to above constraints
+    minimize(sum(x))
+    subject to
+        
+        % input capacitance is an affine function of sizes
+        Cin  = Cin_norm .* x;
+        Cint = Cint_norm .* x;
+        
+        % driving resistance is inversily proportional to sizes
+        R = Rdrv_norm ./ x;
+        
+        % gate delay is the product of its driving resistance and load cap.
+        Cload = cvx(zeros(N, 1));
+        for gate = 1:N
+            if ~ismember(FO{gate}, primary_outputs)
+                Cload(gate) = sum(Cin(FO{gate}));
+            else
+                Cload(gate) = Cin_po(FO{gate});
+            end
+        end
+        
+        % delay
+        D = 0.69 * ones(N, 1) .* R .* (Cint + Cload);
+        
+        % create timing constraints
+        for gate = 1:N
+            if ~ismember(FI{gate}, primary_inputs)
+                for j = FI{gate}
+                    % enforce T_j + D_j <= T_i over all gates j that drive i
+                    D(gate) + T(j) <= T(gate);
+                end
+            else
+                % enforce D_i <= T_i for gates i connected to primary inputs
+                D(gate) <= T(gate);
+            end
+        end
+        
+        % circuit delay is the max of arrival times for output gates
+        output_gates = [FI{primary_outputs}];
+        circuit_delay = max(T(output_gates));
+        
+        % collect all the constraints
+        circuit_delay <= Dmax;
+        x_min <= x <= x_max;
+cvx_end

--- a/tests/style/dsl/cvx/018.m
+++ b/tests/style/dsl/cvx/018.m
@@ -1,0 +1,15 @@
+cvx_begin sdp quiet
+    variables w(m,3) t(m,2) s(1,2)
+    variable G(N,N) symmetric
+    variable C(N,N) symmetric
+    minimize(sum(s))
+    subject to
+        G == reshape(GG * [1; w(:)], N, N);
+        C == reshape(CC * [1; w(:); t(:)], N, N);
+        delay * G - C >= 0;
+        wmin <= w(:) <= wmax;
+        t(:) <= 1 / smin;
+        s(:) <= smax;
+        inv_pos(t(:, 1)) <= s(1) - w(:, 1) - 0.5 * w(:, 2);
+        inv_pos(t(:, 2)) <= s(2) - w(:, 3) - 0.5 * w(:, 2);
+cvx_end

--- a/tests/style/dsl/cvx/019.m
+++ b/tests/style/dsl/cvx/019.m
@@ -1,0 +1,11 @@
+cvx_begin sdp quiet
+    variable x(6)
+    variable G(n,n) symmetric
+    variable C(n,n) symmetric
+    minimize(sum(x))
+    subject to
+        G == reshape(GG * [1; x], n, n);
+        C == reshape(CC * [1; x], n, n);
+        delay * G - C >= 0;
+        0 <= x <= wmax;
+cvx_end

--- a/tests/style/dsl/cvx/020.m
+++ b/tests/style/dsl/cvx/020.m
@@ -1,0 +1,91 @@
+cvx_begin gp quiet
+    % optimization variables
+    variable D        % diameter of loop inductor
+    variable W        % width of loop inductor
+    variable SRF      % self resonance frequency
+    variable l        % length of CMOS transistor
+    variable w        % width of CMOS transistor
+    variable Imax     % maximum current through CMOS transistor
+    variable VOsc     % differential voltage amplitude
+    variable CT       % total capacitance of oscillator
+    variable Csw      % maximum switching capacitance
+    variable Cvar     % minimum variable capacitance
+    variable IBias    % bias current
+    variable CMaxFreq % capacitor max frequency
+    
+    % minimize power = Vdd*IBias;
+    minimize(Vdd * IBias)
+    subject to
+        % *******************************************%
+        % loop inductor definitions and constraints %
+        % *******************************************%
+        SRFSpec  = 3 * F;
+        omegaSRF = 2 * pi * SRF;
+        
+        % inductance
+        L = 2.1e-06 * D^(1.28) * (W)^(-0.25) * (F)^(-0.01);
+        % series resistance
+        R = 0.1 * D / W + 3e-6 * D * W^(-0.84) * F^(0.5) + 5e-9 * D * W^(-0.76) * F^(0.75) + 0.02 * D * W * F;
+        % effective capacitance
+        C = 1e-11 * D + 5e-6 * D * W;
+        
+        % area, tank conductance, and inverse quality factor
+        Area = (D + W)^2;
+        G    = R / (omega * L)^2;
+        invQ = R / (omega * L);
+        
+        % loop constraints
+        Area <= 0.25e-6;
+        W <= 30e-6;
+        5e-6 <= W;
+        10 * W <= D;
+        D <= 100 * W;
+        SRFSpec <= SRF;
+        omegaSRF^2 * L * C <= 1;
+        
+        % ****************************************%
+        % transistor definitions and constraints %
+        % ****************************************%
+        GM  = 6e-3 * (w / l)^0.6 * (Imax / 2)^(0.4);
+        GD  = 4e-10 * (w / l)^0.4 * (Imax / 2)^(0.6) * 1 / l;
+        Vgs = 0.34 + 1e-8 / l + 800 * (Imax * l / (2 * w))^0.7;
+        Cgs = 1e-2 * w * l;
+        Cgd = 1e-9 * w;
+        Cdb = 1e-9 * w;
+        
+        % transistor constraints
+        2e-6 <= w;
+        0.13e-6 <= l;
+        l <= 1e-6;
+        
+        % ***************************************************%
+        % overall LC oscillator definitions and constraints %
+        % ***************************************************%
+        invVOsc = (G + GD) / IBias;
+        
+        % phase noise
+        kT4  = 4 * 1.38e-23 * 300;
+        kT4G = 2 * kT4;
+        LoopCurrentNoise = kT4 * G;
+        TransistorCurrentNoise = 0.5 * kT4G * GM;
+        PN = 1 / (160 * (FOff * VOsc * CT)^2) * (LoopCurrentNoise + TransistorCurrentNoise);
+        
+        % capacitance
+        Cfix = C + 0.5 * (CL + Cgs + Cdb + 4 * Cgd); % fixed capacitance
+        CDiffMaxFreq = Cfix + 0.5 * Cvar;
+        
+        invLoopGain = (G + 0.5 * GD) / (0.5 * GM);
+        
+        % LC oscillator constraints
+        PN <= PNSpec;
+        omega^2 * L * CT == 1;
+        omega^2 * (1 + T)^2 * L * CMaxFreq == 1;
+        4 * T / ((1 - T^2)^2) * CT <= Csw * (1 + CvarCswLSBOverlap / CswSegs);
+        Csw * CvarCswLSBOverlap / CswSegs <= 0.5 * Cvar * (CvarRatio - 1);
+        CDiffMaxFreq <= CMaxFreq;
+        VOsc + 2 * Vbias <= 2 * Vdd;
+        VOsc * invVOsc <= 1;
+        invLoopGain * LoopGainSpec <= 1; % loop gain spec
+        Vbias + Vgs + IBias / 2 * R / 2 <= Vdd;  % bias constraint spec
+        Imax == IBias;
+cvx_end

--- a/tests/style/dsl/cvx/021.m
+++ b/tests/style/dsl/cvx/021.m
@@ -1,0 +1,12 @@
+cvx_begin
+    variable x_l1(n)
+    minimize(norm(x_l1, 1))
+    subject to
+        A * x_l1 <= b;
+cvx_end
+cvx_begin quiet
+    variable x_log(n)
+    minimize(sum(W .* abs(x_log)))
+    subject to
+        A * x_log <= b;
+cvx_end

--- a/tests/style/dsl/cvx/022.m
+++ b/tests/style/dsl/cvx/022.m
@@ -1,0 +1,8 @@
+cvx_begin
+    variables lambda(m)
+    minimize(sum(lambda))
+    subject to
+        A' * lambda == 0;
+        b' * lambda == -1;
+        lambda >= 0;
+cvx_end

--- a/tests/style/dsl/cvx/023.m
+++ b/tests/style/dsl/cvx/023.m
@@ -1,0 +1,4 @@
+cvx_begin
+    variable x(n)
+    minimize(sum(max(A * x - b, 0)))
+cvx_end

--- a/tests/style/dsl/cvx/024.m
+++ b/tests/style/dsl/cvx/024.m
@@ -1,0 +1,18 @@
+cvx_begin
+    variable x1(n)
+    minimize (quad_form(x1, sig))
+    p_mean' * x1 >= r_min;
+    ones(1, n) * x1 == 1;
+    x1 >= 0;
+    sum_largest(x1, r) <= alpha;
+cvx_end
+cvx_begin
+    variables x2(n) u(n) t(1)
+    minimize (quad_form(x2, sig))
+    p_mean' * x2 >= r_min;
+    sum(x2) == 1;
+    x2 >= 0;
+    r * t + sum(u) <= alpha;
+    t * ones(n, 1) + u >= x2;
+    u >= 0;
+cvx_end

--- a/tests/style/dsl/cvx/025.m
+++ b/tests/style/dsl/cvx/025.m
@@ -1,0 +1,14 @@
+cvx_begin
+    variables u(n) t1
+    minimize (t1)
+    u >= 0;
+    ones(1, n) * u == 1;
+    P' * u <= t1 * ones(m, 1);
+cvx_end
+cvx_begin
+    variables v(m) t2
+    maximize (t2)
+    v >= 0;
+    ones(1, m) * v == 1;
+    P * v >= t2 * ones(n, 1);
+cvx_end

--- a/tests/style/dsl/cvx/026.m
+++ b/tests/style/dsl/cvx/026.m
@@ -1,0 +1,5 @@
+cvx_begin quiet
+    variable x(1)
+    minimize (quad_form(x, 1) + 1)
+    quad_form(x, 1) - 6 * x + 8 <= u(i);
+cvx_end

--- a/tests/style/dsl/cvx/027.m
+++ b/tests/style/dsl/cvx/027.m
@@ -1,0 +1,8 @@
+cvx_begin
+    variable x(n)
+    dual variables lam1 lam2 lam3
+    minimize(0.5 * quad_form(x, P0) + q0' * x + r0)
+    lam1:0.5 * quad_form(x, P1) + q1' * x + r1 <= 0;
+    lam2:0.5 * quad_form(x, P2) + q2' * x + r2 <= 0;
+    lam3:0.5 * quad_form(x, P3) + q3' * x + r3 <= 0;
+cvx_end

--- a/tests/style/dsl/cvx/028.m
+++ b/tests/style/dsl/cvx/028.m
@@ -1,0 +1,11 @@
+cvx_begin sdp
+    variable nu(n)
+    maximize (-sum(nu))
+    W + diag(nu) >= 0;
+cvx_end
+cvx_begin sdp
+    variable X(n,n) symmetric
+    minimize (trace(W * X))
+    diag(X) == 1;
+    X >= 0;
+cvx_end

--- a/tests/style/dsl/cvx/029.m
+++ b/tests/style/dsl/cvx/029.m
@@ -1,0 +1,4 @@
+cvx_begin quiet
+    variable x(3)
+    minimize (norm(A * x + b + epsilon(i) * d, 1))
+cvx_end

--- a/tests/style/dsl/cvx/030.m
+++ b/tests/style/dsl/cvx/030.m
@@ -1,0 +1,25 @@
+cvx_begin quiet
+    variable x(n)
+    minimize (norm (A * x - b, p))
+cvx_end
+cvx_begin quiet
+    variables x(n) y(m)
+    minimize (norm (y, p))
+    A * x - b == y;
+cvx_end
+cvx_begin quiet
+    variable nu(m)
+    maximize (b' * nu)
+    norm(nu, q) <= 1;
+    A' * nu == 0;
+cvx_end
+cvx_begin quiet
+    variables x(n) y(m)
+    minimize (0.5 * square_pos (norm (y, p)))
+    A * x - b == y;
+cvx_end
+cvx_begin quiet
+    variable nu(m)
+    maximize (-0.5 * square_pos (norm (nu, q)) + b' * nu)
+    A' * nu == 0;
+cvx_end

--- a/tests/style/dsl/cvx/031.m
+++ b/tests/style/dsl/cvx/031.m
@@ -1,0 +1,12 @@
+cvx_begin
+    variable u(n)
+    minimize (max (P' * u))
+    u >= 0;
+    ones(1, n) * u == 1;
+cvx_end
+cvx_begin
+    variable v(m)
+    maximize (min (P * v))
+    v >= 0;
+    ones(1, m) * v == 1;
+cvx_end

--- a/tests/style/dsl/cvx/032.m
+++ b/tests/style/dsl/cvx/032.m
@@ -1,0 +1,12 @@
+cvx_begin
+    variable x(n)
+    maximize(sum(log(x)))
+    subject to
+        A * x <= c;
+cvx_end
+cvx_begin
+    variable lambda(L)
+    minimize(c' * lambda - sum(log(A' * lambda)) - n)
+    subject to
+        lambda >= 0;
+cvx_end

--- a/tests/style/dsl/cvx/033.m
+++ b/tests/style/dsl/cvx/033.m
@@ -1,0 +1,13 @@
+cvx_begin sdp
+    variable Asqr(n,n) symmetric
+    variable btilde(n)
+    variable t(m)
+    maximize(det_rootn(Asqr))
+    subject to
+        t >= 0;
+        for i = 1:m
+            [-(Asqr - t(i) * As{i}), -(btilde - t(i) * bs{i}), zeros(n, n)
+            -(btilde - t(i) * bs{i})', -(-1 - t(i) * cs{i}), -btilde'
+            zeros(n, n), -btilde, Asqr] >= 0;
+        end
+cvx_end

--- a/tests/style/dsl/cvx/034.m
+++ b/tests/style/dsl/cvx/034.m
@@ -1,0 +1,8 @@
+cvx_begin
+    variables a(n) b(1) u(N) v(M)
+    minimize (ones(1, N) * u + ones(1, M) * v)
+    X' * a - b >= 1 - u;
+    Y' * a - b <= -(1 - v);
+    u >= 0;
+    v >= 0;
+cvx_end

--- a/tests/style/dsl/cvx/035.m
+++ b/tests/style/dsl/cvx/035.m
@@ -1,0 +1,5 @@
+cvx_begin quiet
+    variable x(n)
+    minimize (square_pos(norm(x - x0)))
+    a' * x == b;
+cvx_end

--- a/tests/style/dsl/cvx/036.m
+++ b/tests/style/dsl/cvx/036.m
@@ -1,0 +1,9 @@
+cvx_begin
+    variable B(n,n) symmetric
+    variable d(n)
+    maximize(det_rootn(B))
+    subject to
+        for i = 1:m
+            norm(B * A(i, :)', 2) + A(i, :) * d <= b(i);
+        end
+cvx_end

--- a/tests/style/dsl/cvx/037.m
+++ b/tests/style/dsl/cvx/037.m
@@ -1,0 +1,9 @@
+cvx_begin
+    variables x(n) y(n) w(n)
+    dual variables lam muu z
+    minimize (norm(w, 2))
+    subject to
+        lam:square_pos(norm (A * x + b)) <= 1;
+        muu:square_pos(norm (C * y + d)) <= 1;
+        z:x - y == w;
+cvx_end

--- a/tests/style/dsl/cvx/038.m
+++ b/tests/style/dsl/cvx/038.m
@@ -1,0 +1,8 @@
+cvx_begin
+    variables a(n) b(1) u(N) v(M)
+    minimize (norm(a) + g * (ones(1, N) * u + ones(1, M) * v))
+    X' * a - b >= 1 - u;
+    Y' * a - b <= -(1 - v);
+    u >= 0;
+    v >= 0;
+cvx_end

--- a/tests/style/dsl/cvx/039.m
+++ b/tests/style/dsl/cvx/039.m
@@ -1,0 +1,6 @@
+cvx_begin quiet
+    variable x(n)
+    minimize (norm(x - x0))
+    x <= u;
+    x >= l;
+cvx_end

--- a/tests/style/dsl/cvx/040.m
+++ b/tests/style/dsl/cvx/040.m
@@ -1,0 +1,8 @@
+cvx_begin
+    variables a(np) t(1)
+    minimize (t)
+    a' * monX <= t;
+    a' * monY >= -t;
+    % For normalization purposes only
+    norm(a) <= 1;
+cvx_end

--- a/tests/style/dsl/cvx/041.m
+++ b/tests/style/dsl/cvx/041.m
@@ -1,0 +1,21 @@
+cvx_begin quiet
+    variables x(n) y(n) w(n) h(n) W H
+    minimize (W + H)
+    x >= r;
+    y >= r;
+    w >= 0;
+    h >= 0;
+    x(5) + w(5) + r <= W;    % No rectangles at the right of Rectangle 5
+    x(1) + w(1) + r <= x(3); % Rectangle 1 is at the left of Rectangle 3
+    x(2) + w(2) + r <= x(3); % Rectangle 2 is at the left of Rectangle 3
+    x(3) + w(3) + r <= x(5); % Rectangle 3 is at the left of Rectangle 5
+    x(4) + w(4) + r <= x(5); % Rectangle 4 is at the left of Rectangle 5
+    y(4) + h(4) + r <= H;    % No rectangles on top of Rectangle 4
+    y(5) + h(5) + r <= H;    % No rectangles on top of Rectangle 5
+    y(2) + h(2) + r <= y(1); % Rectangle 2 is below Rectangle 1
+    y(1) + h(1) + r <= y(4); % Rectangle 1 is below Rectangle 4
+    y(3) + h(3) + r <= y(4); % Rectangle 3 is below Rectangle 4
+    w <= 5 * h;                % Aspect ratio constraints
+    h <= 5 * w;
+    w' >= quad_over_lin([A.^.5; zeros(1, n)], h');
+cvx_end

--- a/tests/style/dsl/cvx/042.m
+++ b/tests/style/dsl/cvx/042.m
@@ -1,0 +1,4 @@
+cvx_begin
+    variable x(2)
+    minimize (sum(square_pos(norms(x * ones(1, K) - P, 2))))
+cvx_end

--- a/tests/style/dsl/cvx/043.m
+++ b/tests/style/dsl/cvx/043.m
@@ -1,0 +1,7 @@
+cvx_begin quiet
+    variables muu(n) lambda(m)
+    maximize (muu' * x0 - b' * lambda)
+    A' * lambda == muu;
+    norm(muu) <= 1;
+    lambda >= 0;
+cvx_end

--- a/tests/style/dsl/cvx/044.m
+++ b/tests/style/dsl/cvx/044.m
@@ -1,0 +1,5 @@
+cvx_begin
+    variable x(n)
+    minimize -sum(log(b-A*x))
+    F * x == g;
+cvx_end

--- a/tests/style/dsl/cvx/045.m
+++ b/tests/style/dsl/cvx/045.m
@@ -1,0 +1,9 @@
+cvx_begin
+    variables lam(m) muu(m) z(n)
+    maximize (-b1' * lam - b2' * muu)
+    A1' * lam + z == 0;
+    A2' * muu - z == 0;
+    norm(z) <= 1;
+    -lam <= 0;
+    -muu <= 0;
+cvx_end

--- a/tests/style/dsl/cvx/046.m
+++ b/tests/style/dsl/cvx/046.m
@@ -1,0 +1,5 @@
+cvx_begin sdp quiet
+    variable X(n,n) symmetric
+    minimize (norm(X - X0, 'fro'))
+    X >= 0;
+cvx_end

--- a/tests/style/dsl/cvx/047.m
+++ b/tests/style/dsl/cvx/047.m
@@ -1,0 +1,8 @@
+cvx_begin
+    variable x1(2)
+    minimize (sum(norms(x1 * ones(1, K) - P, 1)))
+cvx_end
+cvx_begin
+    variable x2(2)
+    minimize (sum(norms(x2 * ones(1, K) - P, 2)))
+cvx_end

--- a/tests/style/dsl/cvx/048.m
+++ b/tests/style/dsl/cvx/048.m
@@ -1,0 +1,6 @@
+cvx_begin
+    variables x(n) y(n)
+    minimize (norm(x - y))
+    A1 * x <= b1;
+    A2 * y <= b2;
+cvx_end

--- a/tests/style/dsl/cvx/049.m
+++ b/tests/style/dsl/cvx/049.m
@@ -1,0 +1,10 @@
+cvx_begin quiet
+    variable xs0(n)
+    minimize (square_pos(norm(xs0 - x0)))
+    a' * xs0 <= b;
+cvx_end
+cvx_begin quiet
+    variable xs1(n)
+    minimize (square_pos(norm(xs1 - x1)))
+    a' * xs1 <= b;
+cvx_end

--- a/tests/style/dsl/cvx/050.m
+++ b/tests/style/dsl/cvx/050.m
@@ -1,0 +1,5 @@
+cvx_begin
+    variables a(n) b(1)
+    X' * a - b >= 1;
+    Y' * a - b <= -1;
+cvx_end

--- a/tests/style/dsl/cvx/051.m
+++ b/tests/style/dsl/cvx/051.m
@@ -1,0 +1,5 @@
+cvx_begin quiet
+    variable x(n)
+    minimize (norm(x - x0))
+    x >= 0;
+cvx_end

--- a/tests/style/dsl/cvx/052.m
+++ b/tests/style/dsl/cvx/052.m
@@ -1,0 +1,7 @@
+cvx_begin sdp
+    variable P(n,n) symmetric
+    variables q(n) r(1)
+    P <= -eye(n);
+    sum((X' * P) .* X', 2) + X' * q + r >= +1;
+    sum((Y' * P) .* Y', 2) + Y' * q + r <= -1;
+cvx_end

--- a/tests/style/dsl/cvx/053.m
+++ b/tests/style/dsl/cvx/053.m
@@ -1,0 +1,5 @@
+cvx_begin
+    variable x(N+M,2)
+    minimize (sum(square_pos(norms(A * x, 2, 2))))
+    x(N + [1:M], :) == fixed;
+cvx_end

--- a/tests/style/dsl/cvx/054.m
+++ b/tests/style/dsl/cvx/054.m
@@ -1,0 +1,5 @@
+cvx_begin
+    variable x(N+M,2)
+    minimize (sum(norms(A * x, 2, 2)))
+    x(N + [1:M], :) == fixed;
+cvx_end

--- a/tests/style/dsl/cvx/055.m
+++ b/tests/style/dsl/cvx/055.m
@@ -1,0 +1,7 @@
+cvx_begin
+    variables a(n) b(1) t(1)
+    maximize (t)
+    X' * a - b >= t;
+    Y' * a - b <= -t;
+    norm(a) <= 1;
+cvx_end

--- a/tests/style/dsl/cvx/056.m
+++ b/tests/style/dsl/cvx/056.m
@@ -1,0 +1,28 @@
+cvx_begin sdp
+    variable C1(n,n) symmetric
+    maximize (C1(1, 4))
+    C1 >= 0;
+    diag(C1) == ones(n, 1);
+    C1(1, 2) >= 0.6;
+    C1(1, 2) <= 0.9;
+    C1(1, 3) >= 0.8;
+    C1(1, 3) <= 0.9;
+    C1(2, 4) >= 0.5;
+    C1(2, 4) <= 0.7;
+    C1(3, 4) >= -0.8;
+    C1(3, 4) <= -0.4;
+cvx_end
+cvx_begin sdp
+    variable C2(n,n) symmetric
+    minimize (C2(1, 4))
+    C2 >= 0;
+    diag(C2) == ones(n, 1);
+    C2(1, 2) >= 0.6;
+    C2(1, 2) <= 0.9;
+    C2(1, 3) >= 0.8;
+    C2(1, 3) <= 0.9;
+    C2(2, 4) >= 0.5;
+    C2(2, 4) <= 0.7;
+    C2(3, 4) >= -0.8;
+    C2(3, 4) <= -0.4;
+cvx_end

--- a/tests/style/dsl/cvx/057.m
+++ b/tests/style/dsl/cvx/057.m
@@ -1,0 +1,33 @@
+cvx_begin quiet
+    variables x(n) y(n) w(n) h(n) W H
+    minimize (W + H)
+    w >= 0;
+    h >= 0;
+    x(leafs_H) >= rho;
+    y(leafs_V) >= rho;
+    x(roots_H) + w(roots_H) + rho <= W;
+    y(roots_V) + h(roots_V) + rho <= H;
+    for i = 1:length(nodes_H)
+        node = nodes_H(i);
+        c = adj_H(node, :);
+        prnt = find(c > 0)';
+        m = length(prnt);
+        x(node) + w(node) + rho <= x(prnt);
+    end
+    
+    for i = 1:length(nodes_V)
+        node = nodes_V(i);
+        c = adj_V(node, :);
+        prnt = find(c > 0)';
+        m = length(prnt);
+        y(node) + h(node) + rho <= y(prnt);
+    end
+    
+    if sum(size(u)) ~= 0
+        h <= u .* w;
+    end
+    if sum(size(l)) ~= 0
+        h >= l .* w;
+    end
+    w' >= quad_over_lin([Amin.^.5; zeros(1, n)], h');
+cvx_end

--- a/tests/style/dsl/cvx/058.m
+++ b/tests/style/dsl/cvx/058.m
@@ -1,0 +1,6 @@
+cvx_begin
+    variables a(np) t(1)
+    minimize (t)
+    a' * monX <= t;
+    a' * monY >= -t;
+cvx_end

--- a/tests/style/dsl/cvx/059.m
+++ b/tests/style/dsl/cvx/059.m
@@ -1,0 +1,6 @@
+cvx_begin
+    variables x(n) y(n)
+    minimize (norm(x - y))
+    norm(x, 1) <= 2;
+    norm(y - [4; 3], inf) <= 1;
+cvx_end

--- a/tests/style/dsl/cvx/060.m
+++ b/tests/style/dsl/cvx/060.m
@@ -1,0 +1,5 @@
+cvx_begin
+    variable x(N+M,2)
+    minimize (sum(square_pos(square_pos(norms(A * x, 2, 2)))))
+    x(N + [1:M], :) == fixed;
+cvx_end

--- a/tests/style/dsl/cvx/061.m
+++ b/tests/style/dsl/cvx/061.m
@@ -1,0 +1,7 @@
+cvx_begin
+    variable A(n,n) symmetric
+    variable b(n)
+    maximize(det_rootn(A))
+    subject to
+        norms(A * x + b * ones(1, m), 2) <= 1;
+cvx_end

--- a/tests/style/dsl/cvx/062.m
+++ b/tests/style/dsl/cvx/062.m
@@ -1,0 +1,14 @@
+cvx_begin gp
+    % optimization variables
+    variables z(n) t(q) s(m)
+    
+    minimize(prod(t) * prod(s))
+    subject to
+        for k = 1:q
+            prod(z.^(X(k, :)')) <= t(k);
+        end
+        
+        for k = 1:m
+            1 + prod(z.^(-X(k, :)')) <= s(k);
+        end
+cvx_end

--- a/tests/style/dsl/cvx/063.m
+++ b/tests/style/dsl/cvx/063.m
@@ -1,0 +1,6 @@
+cvx_begin quiet
+    variable u( m )
+    minimize(b' * u + 0.5 * sum_square(chol(Sigma) * A' * u))
+    subject to
+        u >= 0;
+cvx_end

--- a/tests/style/dsl/cvx/064.m
+++ b/tests/style/dsl/cvx/064.m
@@ -1,0 +1,26 @@
+cvx_begin
+    variable lambda(p)
+    maximize (det_rootn(V * diag(lambda) * V'))
+    subject to
+        sum(lambda) == 1;
+        lambda >= 0;
+cvx_end
+cvx_begin sdp
+    variables lambda(p) u(n)
+    minimize (sum(u))
+    subject to
+        for k = 1:n
+            [V * diag(lambda) * V'  e(:, k)
+            e(k, :)             u(k)] >= 0;
+        end
+        sum(lambda) == 1;
+        lambda >= 0;
+cvx_end
+cvx_begin sdp
+    variables t lambda(p)
+    maximize (t)
+    subject to
+        V * diag(lambda) * V' >= t * eye(n, n);
+        sum(lambda) == 1;
+        lambda >= 0;
+cvx_end

--- a/tests/style/dsl/cvx/065.m
+++ b/tests/style/dsl/cvx/065.m
@@ -1,0 +1,6 @@
+cvx_begin sdp
+    variable S(n,n) symmetric
+    maximize(log_det(S) - trace(S * Y))
+    S >= Ui;
+    S <= Li;
+cvx_end

--- a/tests/style/dsl/cvx/066.m
+++ b/tests/style/dsl/cvx/066.m
@@ -1,0 +1,20 @@
+cvx_begin
+    variables pent(n)
+    maximize(sum(entr(pent)))
+    sum(pent) == 1;
+    A * pent <= b;
+cvx_end
+cvx_begin quiet
+    variable p( n )
+    minimize sum( p(1:t) )
+    p >= 0;
+    sum(p) == 1;
+    A * p <= b;
+cvx_end
+cvx_begin quiet
+    variable p( n )
+    maximize sum( p(1:t) )
+    p >= 0;
+    sum(p) == 1;
+    A * p <= b;
+cvx_end

--- a/tests/style/dsl/cvx/067.m
+++ b/tests/style/dsl/cvx/067.m
@@ -1,0 +1,8 @@
+cvx_begin
+    variables T( m, n ) D( m, m )
+    minimize max( D(1,2), D(2,1) )
+    subject to
+        D == T * P;
+        sum(T, 1) == 1;
+        T >= 0;
+cvx_end

--- a/tests/style/dsl/cvx/068.m
+++ b/tests/style/dsl/cvx/068.m
@@ -1,0 +1,14 @@
+cvx_begin sdp quiet
+    variable P(n,n) symmetric
+    variables q(n) r tau(m)
+    dual variables Z{m}
+    maximize(1 - trace(Sigma * P) - r)
+    subject to
+        for i = 1:m
+            qadj = q - 0.5 * tau(i) * A(i, :)';
+            radj = r - 1 + tau(i) * b(i);
+            [P, qadj; qadj', radj] >= 0:Z{i};
+        end
+        [P, q; q', r] >= 0;
+        tau >= 0;
+cvx_end

--- a/tests/style/dsl/cvx/069.m
+++ b/tests/style/dsl/cvx/069.m
@@ -1,0 +1,4 @@
+cvx_begin
+    variables x(2)
+    maximize(y' * U * x - sum(log_sum_exp([zeros(1, m) x' * U'])))
+cvx_end

--- a/tests/style/dsl/cvx/070.m
+++ b/tests/style/dsl/cvx/070.m
@@ -1,0 +1,4 @@
+cvx_begin
+    variables a(n) b(1)
+    maximize sum(y.*log(a'*u+b) - (a'*u+b))
+cvx_end

--- a/tests/style/dsl/cvx/071.m
+++ b/tests/style/dsl/cvx/071.m
@@ -1,0 +1,4 @@
+cvx_begin quiet
+    variable xhub(n)
+    minimize(sum(huber(A * xhub - b)))
+cvx_end

--- a/tests/style/dsl/cvx/072.m
+++ b/tests/style/dsl/cvx/072.m
@@ -1,0 +1,22 @@
+cvx_begin quiet
+    variables u(m+1) g_x(m+1) g_y(m+1)
+    minimize(u(k) - u(m + 1))
+    subject to
+        g_x >= 0;
+        g_y >= 0;
+        ones(m + 1, 1) * u' <= u * ones(1, m + 1) + (g_x * ones(1, m + 1)) .* ...
+        (ones(m + 1, 1) * data(:, 1)' - data(:, 1) * ones(1, m + 1)) + ...
+        (g_y * ones(1, m + 1)) .* (ones(m + 1, 1) * data(:, 2)' - data(:, 2) * ones(1, m + 1));
+        (u * ones(1, m + 1)) .* Pweak >= (ones(m + 1, 1) * u') .* Pweak;
+cvx_end
+cvx_begin quiet
+    variables u(m+1) g_x(m+1) g_y(m+1)
+    maximize(u(k) - u(m + 1))
+    subject to
+        g_x >= 0;
+        g_y >= 0;
+        ones(m + 1, 1) * u' <= u * ones(1, m + 1) + (g_x * ones(1, m + 1)) .* ...
+        (ones(m + 1, 1) * data(:, 1)' - data(:, 1) * ones(1, m + 1)) + ...
+        (g_y * ones(1, m + 1)) .* (ones(m + 1, 1) * data(:, 2)' - data(:, 2) * ones(1, m + 1));
+        (u * ones(1, m + 1)) .* Pweak >= (ones(m + 1, 1) * u') .* Pweak;
+cvx_end

--- a/tests/style/dsl/cvx/073.m
+++ b/tests/style/dsl/cvx/073.m
@@ -1,0 +1,6 @@
+cvx_begin quiet
+    variable x(n)
+    minimize(norm(A * x - b))
+    subject to
+        norm(x, 1) <= alpha;
+cvx_end

--- a/tests/style/dsl/cvx/074.m
+++ b/tests/style/dsl/cvx/074.m
@@ -1,0 +1,4 @@
+cvx_begin quiet
+    variable x1(n)
+    minimize (norm(A * x1 - v', inf))
+cvx_end

--- a/tests/style/dsl/cvx/075.m
+++ b/tests/style/dsl/cvx/075.m
@@ -1,0 +1,12 @@
+cvx_begin
+    variable x1(n)
+    minimize(norm(A * x1 + b, 1))
+cvx_end
+cvx_begin
+    variable xdz(n)
+    minimize(sum(max(abs(A * xdz + b) - dz, 0)))
+cvx_end
+cvx_begin
+    variable xlb(n)
+    minimize norm(A*xlb+b,Inf)
+cvx_end

--- a/tests/style/dsl/cvx/076.m
+++ b/tests/style/dsl/cvx/076.m
@@ -1,0 +1,6 @@
+cvx_begin quiet
+    variable u(N+1)
+    minimize (square_pos(norm(H * u - y_des)) / (N + 1) + ...
+    eta(i) * square_pos(norm(u)) / (N + 1) + ...
+    delta(i) * square_pos(norm(D * u)) / N);
+cvx_end

--- a/tests/style/dsl/cvx/077.m
+++ b/tests/style/dsl/cvx/077.m
@@ -1,0 +1,10 @@
+cvx_begin quiet
+    variable x(n)
+    minimize(norm(x - corrupt) + lambda * norm(x(2:n) - x(1:n - 1)))
+cvx_end
+cvx_begin quiet
+    variable x(n)
+    minimize(norm(x(2:n) - x(1:n - 1)))
+    subject to
+        norm(x - corrupt) <= alpha;
+cvx_end

--- a/tests/style/dsl/cvx/078.m
+++ b/tests/style/dsl/cvx/078.m
@@ -1,0 +1,4 @@
+cvx_begin
+    variable x(30561)
+    minimize(sum_square(A * x - b) + norm(x, 1))
+cvx_end

--- a/tests/style/dsl/cvx/079.m
+++ b/tests/style/dsl/cvx/079.m
@@ -1,0 +1,4 @@
+cvx_begin quiet
+    variable x(n)
+    minimize (norm(x - corrupt) + lambdas(i) * norm(D * x))
+cvx_end

--- a/tests/style/dsl/cvx/080.m
+++ b/tests/style/dsl/cvx/080.m
@@ -1,0 +1,8 @@
+cvx_begin sdp quiet
+    variables t lambda xrob(n)
+    minimize(t + lambda)
+    subject to
+        [eye(m) A1 * xrob A2 * xrob A0 * xrob - b; ...
+        [A1 * xrob A2 * xrob]' lambda * eye(2) zeros(2, 1); ...
+        [A0 * xrob - b]' zeros(1, 2) t] >= 0;
+cvx_end

--- a/tests/style/dsl/cvx/081.m
+++ b/tests/style/dsl/cvx/081.m
@@ -1,0 +1,12 @@
+cvx_begin quiet
+    variable x_nom(n)
+    minimize (norm(A * x_nom - b))
+cvx_end
+cvx_begin quiet
+    variable x_stoch(n)
+    minimize (square_pos(norm(A * x_stoch - b)) + quad_form(x_stoch, P))
+cvx_end
+cvx_begin quiet
+    variable x_wc(n)
+    minimize (max(norm((A - B) * x_wc - b), norm((A + B) * x_wc - b)))
+cvx_end

--- a/tests/style/dsl/cvx/082.m
+++ b/tests/style/dsl/cvx/082.m
@@ -1,0 +1,24 @@
+cvx_begin quiet
+    variable xrec(n+1)
+    minimize(norm(xrec - corrupt))
+    subject to
+        norm(xrec(2:(n + 1)) - xrec(1:n), 1) <= TVs(i);
+cvx_end
+cvx_begin quiet
+    variable xrec(n+1)
+    minimize(norm(xrec - corrupt))
+    subject to
+        norm(xrec(2:(n + 1)) - xrec(1:n), 1) <= 10;
+cvx_end
+cvx_begin quiet
+    variable xrec(n+1)
+    minimize(norm(xrec - corrupt))
+    subject to
+        norm(xrec(2:(n + 1)) - xrec(1:n), 1) <= 8;
+cvx_end
+cvx_begin quiet
+    variable xrec(n+1)
+    minimize(norm(xrec - corrupt))
+    subject to
+        norm(xrec(2:(n + 1)) - xrec(1:n), 1) <= 5;
+cvx_end

--- a/tests/style/dsl/cvx/083.m
+++ b/tests/style/dsl/cvx/083.m
@@ -1,0 +1,4 @@
+cvx_begin
+    variable x(n)
+    minimize(sum(max(abs(A * x - b) - 1, 0)))
+cvx_end

--- a/tests/style/dsl/cvx/084.m
+++ b/tests/style/dsl/cvx/084.m
@@ -1,0 +1,24 @@
+cvx_begin
+    variables x1(n) x2(n) x3(n)
+    minimize (norm([A1 * x1 A2 * x2 A3 * x3] - v'))
+    % continuity conditions at point a
+    [1 a a^2   a^3] * x1 == [1 a a^2   a^3] * x2;
+    [0 1 2 * a 3 * a^2] * x1 == [0 1 2 * a 3 * a^2] * x2;
+    [0 0   2 6 * a] * x1 == [0 0   2 6 * a] * x2;
+    % continuity conditions at point b
+    [1 b b^2   b^3] * x2 == [1 b b^2   b^3] * x3;
+    [0 1 2 * b 3 * b^2] * x2 == [0 1 2 * b 3 * b^2] * x3;
+    [0 0   2 6 * b] * x2 == [0 0   2 6 * b] * x3;
+cvx_end
+cvx_begin
+    variables xl1(n) xl2(n) xl3(n)
+    minimize (norm([A1 * xl1 A2 * xl2 A3 * xl3] - v', inf))
+    % continuity conditions at point a
+    [1 a a^2   a^3] * xl1 == [1 a a^2   a^3] * xl2;
+    [0 1 2 * a 3 * a^2] * xl1 == [0 1 2 * a 3 * a^2] * xl2;
+    [0 0   2 6 * a] * xl1 == [0 0   2 6 * a] * xl2;
+    % continuity conditions at point b
+    [1 b b^2   b^3] * xl2 == [1 b b^2   b^3] * xl3;
+    [0 1 2 * b 3 * b^2] * xl2 == [0 1 2 * b 3 * b^2] * xl3;
+    [0 0   2 6 * b] * xl2 == [0 0   2 6 * b] * xl3;
+cvx_end

--- a/tests/style/dsl/cvx/085.m
+++ b/tests/style/dsl/cvx/085.m
@@ -1,0 +1,6 @@
+cvx_begin
+    variables yhat(m) g(m)
+    minimize(norm(yns - yhat))
+    subject to
+        yhat * ones(1, m) >= ones(m, 1) * yhat' + (ones(m, 1) * g') .* (u * ones(1, m) - ones(m, 1) * u');
+cvx_end

--- a/tests/style/dsl/cvx/086.m
+++ b/tests/style/dsl/cvx/086.m
@@ -1,0 +1,6 @@
+cvx_begin
+    variable x(n)
+    minimize ((1 / 2) * quad_form(x, P) + q' * x + r)
+    x >= -1;
+    x <=  1;
+cvx_end

--- a/tests/style/dsl/cvx/087.m
+++ b/tests/style/dsl/cvx/087.m
@@ -1,0 +1,7 @@
+cvx_begin
+    variable x(n)
+    y = P * x;
+    maximize (c' * x + sum(entr(y)) / log(2))
+    x >= 0;
+    sum(x) == 1;
+cvx_end

--- a/tests/style/dsl/cvx/088.m
+++ b/tests/style/dsl/cvx/088.m
@@ -1,0 +1,5 @@
+cvx_begin gp
+    variable d(n)
+    minimize(sqrt(sum(sum(diag(d.^2) * (M.^2) * diag(d.^-2)))))
+    % Alternate formulation: norm( diag(d)*abs(M)*diag(1./d), 'fro' )
+cvx_end

--- a/tests/style/dsl/cvx/089.m
+++ b/tests/style/dsl/cvx/089.m
@@ -1,0 +1,7 @@
+cvx_begin
+    variable P(n,n) symmetric
+    minimize(norm(P - (1 / n) * ones(n)))
+    P * ones(n, 1) == ones(n, 1);
+    P >= 0;
+    P(E == 0) == 0;
+cvx_end

--- a/tests/style/dsl/cvx/090.m
+++ b/tests/style/dsl/cvx/090.m
@@ -1,0 +1,9 @@
+cvx_begin
+    variable r(1)
+    variable x_c(2)
+    maximize (r)
+    a1' * x_c + r * norm(a1, 2) <= b(1);
+    a2' * x_c + r * norm(a2, 2) <= b(2);
+    a3' * x_c + r * norm(a3, 2) <= b(3);
+    a4' * x_c + r * norm(a4, 2) <= b(4);
+cvx_end

--- a/tests/style/dsl/cvx/091.m
+++ b/tests/style/dsl/cvx/091.m
@@ -1,0 +1,7 @@
+cvx_begin
+    variable r(1)
+    variable x_c(n)
+    dual variable y
+    maximize (r)
+    y:A * x_c + r * norm_ai <= b;
+cvx_end

--- a/tests/style/dsl/cvx/092.m
+++ b/tests/style/dsl/cvx/092.m
@@ -1,0 +1,5 @@
+cvx_begin sdp
+    variable t
+    minimize (c * t)
+    A >= t * B;
+cvx_end

--- a/tests/style/dsl/cvx/093.m
+++ b/tests/style/dsl/cvx/093.m
@@ -1,0 +1,6 @@
+cvx_begin
+    variable x_opt(n)
+    maximize sum(Pi.*log(P*x_opt))
+    sum(x_opt) == 1;
+    x_opt >= 0;
+cvx_end

--- a/tests/style/dsl/cvx/094.m
+++ b/tests/style/dsl/cvx/094.m
@@ -1,0 +1,21 @@
+cvx_begin sdp
+    % A is a PSD symmetric matrix (n-by-n)
+    variable A(n,n) symmetric
+    A >= 0;
+    
+    % constrained matrix entries.
+    A(1, 1) == 3;
+    A(2, 2) == 2;
+    A(3, 3) == 1;
+    A(4, 4) == 5;
+    % Note that because A is symmetric, these off-diagonal
+    % constraints affect the corresponding element on the
+    % opposite side of the diagonal.
+    A(1, 2) == .5;
+    A(1, 4) == .25;
+    A(2, 3) == .75;
+    
+    % find the solution to the problem
+    maximize(log_det(A))
+    % maximize( det_rootn( A ) )
+cvx_end

--- a/tests/style/dsl/cvx/095.m
+++ b/tests/style/dsl/cvx/095.m
@@ -1,0 +1,23 @@
+cvx_begin gp
+    % optimization variables
+    variables w(N) h(N) v(N+1) y(N+1)
+    
+    % objective is the total volume of the beam
+    % obj = sum of (widths*heights*lengths) over each section
+    % (recall that the length of each segment is set to be 1)
+    minimize(w' * h)
+    subject to
+        % non-recursive formulation
+        d = 6 * F * ones(N, 1) ./ (E * ones(N, 1) .* w .* h.^3);
+        for i = 1:N
+            (2 * i - 1) * d(i) + v(i + 1) <= v(i);
+            (i - 1 / 3) * d(i) + v(i + 1) + y(i + 1) <= y(i);
+        end
+        
+        % constraint set
+        wmin <= w    <= wmax;
+        hmin <= h    <= hmax;
+        Smin <= h ./ w <= Smax;
+        6 * F * [1:N]' ./ (w .* (h.^2)) <= sigma_max;
+        y(1) <= ymax;
+cvx_end

--- a/tests/style/dsl/cvx/096.m
+++ b/tests/style/dsl/cvx/096.m
@@ -1,0 +1,26 @@
+cvx_begin
+    variable x1(n)
+    minimize(matrix_frac(A * x1 + b, eye(m) + B * diag(x1) * B'))
+    x1 >= 0;
+cvx_end
+cvx_begin
+    variable x2(n)
+    variable Y(n,n) diagonal
+    minimize(matrix_frac(A * x2 + b, eye(m) + B * Y * B'))
+    x2 >= 0;
+    Y == diag(x2);
+cvx_end
+cvx_begin
+    variables x3(n) w(n) v(m)
+    minimize(square_pos(norm(v)) + matrix_frac(w, diag(x3)))
+    v + B * w == A * x3 + b;
+    x3 >= 0;
+cvx_end
+cvx_begin
+    variables x4(n) w(n) v(m)
+    variable Y(n,n) diagonal
+    minimize(square_pos(norm(v)) + matrix_frac(w, Y))
+    v + B * w == A * x4 + b;
+    x4 >= 0;
+    Y == diag(x4);
+cvx_end

--- a/tests/style/dsl/cvx/097.m
+++ b/tests/style/dsl/cvx/097.m
@@ -1,0 +1,21 @@
+cvx_begin
+    variable x1(n)
+    minimize(sum(huber(A * x1 - b, M)))
+cvx_end
+cvx_begin
+    variable x2(n)
+    variable w(m)
+    minimize(sum(quad_over_lin(diag(A * x2 - b), w' + 1)) + M^2 * ones(1, m) * w)
+    w >= 0;
+cvx_end
+cvx_begin
+    variable x3(n)
+    variable u(m)
+    variable v(m)
+    minimize(sum(square(u) +  2 * M * v))
+    A * x3 - b <= u + v;
+    A * x3 - b >= -u - v;
+    u >= 0;
+    u <= M;
+    v >= 0;
+cvx_end

--- a/tests/style/dsl/cvx/098.m
+++ b/tests/style/dsl/cvx/098.m
@@ -1,0 +1,20 @@
+cvx_begin gp
+    % optimization variables
+    variables lambda b(4) s(3) v(4) c(2)
+    
+    % objective is the Perron-Frobenius eigenvalue
+    minimize(lambda)
+    subject to
+        % inequality constraints
+        b' * v      <= lambda * v(1);
+        s(1) * v(1) <= lambda * v(2);
+        s(2) * v(2) <= lambda * v(3);
+        s(3) * v(3) <= lambda * v(4);
+        [0.5; 0.5] <= c;
+        c <= [2; 2];
+        % equality constraints
+        b == b_nom .* ((ones(4, 1) * (c(1) / c_nom(1))).^alpha) .* ...
+        ((ones(4, 1) * (c(2) / c_nom(2))).^beta);
+        s == s_nom .* ((ones(3, 1) * (c(1) / c_nom(1))).^gamma) .* ...
+        ((ones(3, 1) * (c(2) / c_nom(2))).^delta);
+cvx_end

--- a/tests/style/dsl/cvx/099.m
+++ b/tests/style/dsl/cvx/099.m
@@ -1,0 +1,26 @@
+cvx_begin gp
+    % optimization variables
+    variables w(N) h(N)
+    
+    % setting up variables relations
+    % (recursive formulation)
+    v = cvx(zeros(N + 1, 1));
+    y = cvx(zeros(N + 1, 1));
+    for i = N:-1:1
+        fprintf(1, 'Building recursive relations for index: %d\n', i);
+        v(i) = 12 * (i - 1 / 2) * F / (E * w(i) * h(i)^3) + v(i + 1);
+        y(i) = 6 * (i - 1 / 3) * F / (E * w(i) * h(i)^3)  + v(i + 1) + y(i + 1);
+    end
+    
+    % objective is the total volume of the beam
+    % obj = sum of (widths*heights*lengths) over each section
+    % (recall that the length of each segment is set to be 1)
+    minimize(w' * h)
+    subject to
+        % constraint set
+        wmin <= w    <= wmax;
+        hmin <= h    <= hmax;
+        Smin <= h ./ w <= Smax;
+        6 * F * [1:N]' ./ (w .* (h.^2)) <= sigma_max;
+        y(1) <= ymax;
+cvx_end

--- a/tests/style/dsl/cvx/100.m
+++ b/tests/style/dsl/cvx/100.m
@@ -1,0 +1,12 @@
+cvx_begin
+    variable r(n,1)
+    
+    % this is a feasibility problem
+    minimize(max(abs(As * r)))
+    subject to
+        % passband constraints
+        Ap * r >= (Lp.^2);
+        Ap * r <= (Up.^2);
+        % nonnegative-real constraint for all frequencies (a bit redundant)
+        A * r >= 0;
+cvx_end

--- a/tests/style/dsl/cvx/101.m
+++ b/tests/style/dsl/cvx/101.m
@@ -1,0 +1,9 @@
+cvx_begin quiet
+    variable h_cur(n+1,1)
+    % feasibility problem
+    % passband bounds
+    Ap * h_cur <= 10^(delta / 20);
+    Ap * h_cur >= 10^(-delta / 20);
+    % stopband bounds
+    abs(As * h_cur) <= 10^(atten_level / 20);
+cvx_end

--- a/tests/style/dsl/cvx/102.m
+++ b/tests/style/dsl/cvx/102.m
@@ -1,0 +1,14 @@
+cvx_begin quiet
+    variable c(M,1)
+    variable d(N-1,1)
+    
+    % feasibility problem
+    % passband constraints
+    (Ap_num * c) <= (10^(+delta / 20))^2 * (Ap_den * [1; d]); % upper constr
+    (Ap_num * c) >= (10^(-delta / 20))^2 * (Ap_den * [1; d]); % lower constr
+    % stopband constraint
+    (As_num * c) <= (Us_cur) * (As_den * [1; d]); % upper constr
+    % nonnegative-real constraint
+    Anum * c >= 0;
+    Aden * [1; d] >= 0;
+cvx_end

--- a/tests/style/dsl/cvx/103.m
+++ b/tests/style/dsl/cvx/103.m
@@ -1,0 +1,6 @@
+cvx_begin quiet
+    variables r_cur(n_cur,1)
+    minimize(max(abs(As * r_cur)))
+    10^(-delta / 10) <= Ap * r_cur <= 10^(+delta / 10);
+    A * r_cur >= 0;
+cvx_end

--- a/tests/style/dsl/cvx/104.m
+++ b/tests/style/dsl/cvx/104.m
@@ -1,0 +1,13 @@
+cvx_begin
+    variable delta
+    variable h(n+1,1)
+    
+    minimize(delta)
+    subject to
+        % passband bounds
+        Ap * h <= delta;
+        inv_pos(Ap * h) <= delta;
+        
+        % stopband bounds
+        abs(As * h) <= Us;
+cvx_end

--- a/tests/style/dsl/cvx/105.m
+++ b/tests/style/dsl/cvx/105.m
@@ -1,0 +1,4 @@
+cvx_begin
+    variable h(n,1)
+    minimize(max(abs(A * h - Hdes)))
+cvx_end

--- a/tests/style/dsl/cvx/106.m
+++ b/tests/style/dsl/cvx/106.m
@@ -1,0 +1,12 @@
+cvx_begin
+    variable hf(n,1)
+    minimize(max(abs(G .* (A * hf) - Gdes)))
+cvx_end
+cvx_begin
+    variable t
+    variable ht(n,1)
+    
+    minimize(max(abs(Tconv(times_not_D, :) * ht)))
+    subject to
+        Tconv(D + 1, :) * ht == 1;
+cvx_end

--- a/tests/style/dsl/cvx/107.m
+++ b/tests/style/dsl/cvx/107.m
@@ -1,0 +1,15 @@
+cvx_begin quiet
+    variable c(M,1)
+    variable d(N-1,1)
+    
+    % feasibility problem
+    % passband constraints
+    (Ap_num * c) <= (10^(+delta / 20))^2 * (Ap_den * [1; d]); % upper constr
+    (Ap_num * c) >= (10^(-delta / 20))^2 * (Ap_den * [1; d]); % lower constr
+    % stopband constraint
+    (As1_num * c) <= (Us_cur) * (As1_den * [1; d]); % upper constr
+    (As2_num * c) <= (Us_cur) * (As2_den * [1; d]); % upper constr
+    % nonnegative-real constraint
+    Anum * c >= 0;
+    Aden * [1; d] >= 0;
+cvx_end

--- a/tests/style/dsl/cvx/108.m
+++ b/tests/style/dsl/cvx/108.m
@@ -1,0 +1,6 @@
+cvx_begin
+    variable h(n+1,1)
+    minimize(norm(As * h, Inf))
+    subject to
+        10^(-ripple / 20) <= Ap * h <= 10^(ripple / 20);
+cvx_end

--- a/tests/style/dsl/cvx/109.m
+++ b/tests/style/dsl/cvx/109.m
@@ -1,0 +1,10 @@
+cvx_begin
+    variable r(n,1)   % auto-correlation coefficients
+    variable R(m,1)   % power spectrum
+    
+    % log-chebychev minimax design
+    minimize(max(max([R ./ (D.^2)  (D.^2) .* inv_pos(R)]')))
+    subject to
+        % power spectrum constraint
+        R == Al * r;
+cvx_end

--- a/tests/style/dsl/cvx/110.m
+++ b/tests/style/dsl/cvx/110.m
@@ -1,0 +1,5 @@
+cvx_begin quiet
+    variable h_cur(n_cur+1,1)
+    minimize(max(abs(As * h_cur)))
+    10^(-delta / 20) <= Ap * h_cur <=  10^(+delta / 20);
+cvx_end

--- a/tests/style/dsl/cvx/111.m
+++ b/tests/style/dsl/cvx/111.m
@@ -1,0 +1,4 @@
+cvx_begin
+    variable x(n)
+    minimize(0.5 * sum_square(y - x) + lambda * norm(D * x, 1))
+cvx_end

--- a/tests/style/dsl/cvx/112.m
+++ b/tests/style/dsl/cvx/112.m
@@ -1,0 +1,4 @@
+cvx_begin
+    variable x(n)
+    minimize -sum(w.*log(b-A*x))
+cvx_end

--- a/tests/style/dsl/cvx/113.m
+++ b/tests/style/dsl/cvx/113.m
@@ -1,0 +1,5 @@
+cvx_begin sdp quiet
+    variable S(n,n) symmetric
+    maximize log_det(S) - trace(S*Y) - lambda(i)*sum(sum(abs(S)))
+    S >= 0;
+cvx_end

--- a/tests/style/dsl/cvx/114.m
+++ b/tests/style/dsl/cvx/114.m
@@ -1,0 +1,6 @@
+cvx_begin
+    variable x(n)
+    maximize sum(entr(x))
+    A * x == b;
+    F * x <= g;
+cvx_end

--- a/tests/style/dsl/cvx/115.m
+++ b/tests/style/dsl/cvx/115.m
@@ -1,0 +1,6 @@
+cvx_begin sdp
+    variable S(n,n) symmetric
+    maximize log_det(S) - trace(S*Y)
+    sum(sum(abs(S))) <= alpha;
+    S >= 0;
+cvx_end

--- a/tests/style/dsl/cvx/116.m
+++ b/tests/style/dsl/cvx/116.m
@@ -1,0 +1,7 @@
+cvx_begin
+    variable w(n*P) complex
+    minimize(max(abs(As * w)))
+    subject to
+        % target direction equality constraint
+        Atar * w == 1;
+cvx_end

--- a/tests/style/dsl/cvx/117.m
+++ b/tests/style/dsl/cvx/117.m
@@ -1,0 +1,7 @@
+cvx_begin
+    variable w(n) complex
+    minimize(norm(w))
+    subject to
+        Atar * w == 1;
+        abs(As * w) <= 10^(min_sidelobe / 20);
+cvx_end

--- a/tests/style/dsl/cvx/118.m
+++ b/tests/style/dsl/cvx/118.m
@@ -1,0 +1,13 @@
+cvx_begin quiet
+    variable w(n) complex
+    % feasibility problem
+    Atar * w == 1;
+    abs(As * w) <= 10^(min_sidelobe / 20);
+cvx_end
+cvx_begin quiet
+    variable w(n) complex
+    minimize(norm(w))
+    subject to
+        Atar * w == 1;
+        abs(As * w) <= 10^(min_sidelobe / 20);
+cvx_end

--- a/tests/style/dsl/cvx/119.m
+++ b/tests/style/dsl/cvx/119.m
@@ -1,0 +1,9 @@
+cvx_begin
+    variable w(n) complex
+    minimize(max(abs(As * w)))
+    subject to
+        Atar * w == 1;   % target constraint
+        if HAS_NULLS   % nulls constraints
+            Anull * w == 0;
+        end
+cvx_end

--- a/tests/style/dsl/cvx/120.m
+++ b/tests/style/dsl/cvx/120.m
@@ -1,0 +1,14 @@
+cvx_begin
+    variable r(2*n-1,1) complex
+    % minimize stopband attenuation
+    minimize(max(real(As * r)))
+    subject to
+        % passband ripple constraints
+        (10^(-ripple / 20))^2 <= real(Ap * r) <= (10^(+ripple / 20))^2;
+        % nonnegative-real constraint for all frequencies
+        % a bit redundant: the passband frequencies are already constrained
+        real(A * r) >= 0;
+        % auto-correlation symmetry constraints
+        imag(r(n)) == 0;
+        r(n - 1:-1:1) == conj(r(n + 1:end));
+cvx_end

--- a/tests/style/dsl/cvx/121.m
+++ b/tests/style/dsl/cvx/121.m
@@ -1,0 +1,24 @@
+cvx_begin gp quiet
+    % optimization variables
+    variables v(M) y(M) w(M)
+    
+    % objective function is the base transmit time
+    tau_B = C * w(1);
+    
+    minimize(tau_B)
+    subject to
+        % fixed problem constraints
+        Nmin <= v <= Nmax;
+        
+        for i = 1:M - 1
+            y(i + 1) + v(i)^pwj <= y(i);
+            w(i + 1) + y(i) * v(i)^pwi <= w(i);
+        end
+        
+        % equalities
+        y(M) == v(M)^pwj;
+        w(M) == y(M) * v(M)^pwi;
+        
+        % changing constraint
+        (WB * beta_min_GE(k) / (M * Nref^(g1 - g2) * Dn0)) * y(1) <= 1;
+cvx_end

--- a/tests/style/dsl/cvx/122.m
+++ b/tests/style/dsl/cvx/122.m
@@ -1,0 +1,22 @@
+cvx_begin gp
+    variables v(M) y(M) w(M)
+    
+    % objective function is the base transmit time
+    tau_B = C * w(1);
+    
+    minimize(tau_B)
+    subject to
+        % problem constraints
+        v >= Nmin;
+        v <= Nmax;
+        
+        for i = 1:M - 1
+            if mod(i, 100) == 0 fprintf(1, 'progress counter: %d\n', i);
+            end
+            y(i + 1) + v(i)^pwj <= y(i);
+            w(i + 1) + y(i) * v(i)^pwi <= w(i);
+        end
+        
+        y(M) == v(M)^pwj;
+        w(M) == y(M) * v(M)^pwi;
+cvx_end

--- a/tests/style/dsl/cvx/123.m
+++ b/tests/style/dsl/cvx/123.m
@@ -1,0 +1,14 @@
+cvx_begin gp
+    variable P(n)
+    % objective function is the total transmitter power
+    minimize(sum(P))
+    subject to
+        % formulate the inverse SINR at each receiver using vectorize features
+        Gdiag = diag(G);          % the main diagonal of G matrix
+        Gtilde = G - diag(Gdiag); % G matrix without the main diagonal
+        % inverse SINR
+        inverseSINR = (sigma + Gtilde * P) ./ (Gdiag .* P);
+        % constraints are power limits and minimum SINR level
+        Pmin <= P <= Pmax;
+        inverseSINR <= (1 / SINR_min);
+cvx_end

--- a/tests/style/dsl/cvx/124.m
+++ b/tests/style/dsl/cvx/124.m
@@ -1,0 +1,15 @@
+cvx_begin gp quiet
+    variables wa wb wc wd ha hb hc hd
+    % objective function is the area of the bounding box
+    minimize(max(wa + wb, wc + wd) * (max(ha, hb) + max(hc, hd)))
+    subject to
+        % constraints (now impose the non-changing constraints)
+        ha * wa == a;
+        hb * wb == b;
+        hc * wc == c;
+        hd * wd == d;
+        1 / alpha(n) <= ha / wa <= alpha(n);
+        1 / alpha(n) <= hb / wb <= alpha(n);
+        1 / alpha(n) <= hc / wc <= alpha(n);
+        1 / alpha(n) <= hd / wd <= alpha(n);
+cvx_end

--- a/tests/style/dsl/cvx/125.m
+++ b/tests/style/dsl/cvx/125.m
@@ -1,0 +1,52 @@
+cvx_begin gp quiet
+    % optimization variables
+    variable w(N-1)     % wire width
+    variable T(N)       % arrival time (Elmore delay to node i)
+    
+    % area definition
+    area = sum(w .* l);
+    
+    % wire segment resistance is inversely proportional to widths
+    R = alpha .* l ./ w;
+    R = [Rsource; R];
+    
+    % wire segment capacitance is an affine function of widths
+    C_bar = beta .* l .* w + gamma .* l;
+    C_bar = [0; C_bar];
+    
+    % compute common capacitances for each node (C_tilde in GP tutorial)
+    C_tilde = cvx(zeros(N, 1));
+    for node = [1:N]
+        C_tilde(node, 1) = Cload(node);
+        for k = parent(node)
+            if k > 0
+                C_tilde(node, 1) = C_tilde(node, 1) + C_bar(k);
+            end
+        end
+        for k = children{node}
+            C_tilde(node, 1) = C_tilde(node, 1) + C_bar(k);
+        end
+    end
+    
+    % now compute total downstream capacitances
+    C_total = C_tilde;
+    for node = N:-1:1
+        for k = children{node}
+            C_total(node, 1) = C_total(node, 1) + C_total(k, 1);
+        end
+    end
+    
+    % objective is the critical Elmore delay
+    minimize(max(T(leafs)))
+    subject to
+        % generate Elmore delay constraints
+        R(1) * C_total(1) <= T(1, 1);
+        for node = 2:N
+            R(node) * C_total(node) + T(parent(node), 1) <= T(node, 1);
+        end
+        
+        % area and width constraints
+        area <= Amax;
+        w >= Wmin;
+        w <= Wmax;
+cvx_end

--- a/tests/style/dsl/cvx/126.m
+++ b/tests/style/dsl/cvx/126.m
@@ -1,0 +1,10 @@
+cvx_begin gp quiet
+    variables h w d
+    % objective function is the box volume
+    maximize(h * w * d)
+    subject to
+        2 * (h * w + h * d) <= Awall_k;
+        w * d <= Afloor_n;
+        alpha <= h / w <= beta;
+        gamma <= d / w <= delta;
+cvx_end

--- a/tests/style/dsl/cvx/127.m
+++ b/tests/style/dsl/cvx/127.m
@@ -1,0 +1,37 @@
+cvx_begin gp quiet
+    % optimization variables
+    variable x(m)                 % scale factors
+    variable t(m)                 % arrival times
+    
+    % objective is the upper bound on the overall delay
+    % and that is the max of arrival times for output gates 6 and 7
+    minimize(max(t(6), t(7)))
+    subject to
+        % input capacitance is an affine function of sizes
+        cin = alpha + beta .* x;
+        
+        % load capacitance is the input capacitance times the fan-out matrix
+        % given by Fout = Aout*Ain'
+        cload = (Aout * Ain') * cin;
+        cload(6) = Cout6;          % load capacitance of the output gate 6
+        cload(7) = Cout7;          % load capacitance of othe utput gate 7
+        
+        % delay is the product of its driving resistance R = gamma./x and cload
+        d = cload .* gamma ./ x;
+        
+        % power and area definitions
+        power = (f .* e)' * x;
+        area = a' * x;
+        
+        % scale size, power, and area constraints
+        x >= 1;
+        power <= Pmax(n);
+        area <= Amax(k);
+        
+        % create timing constraints
+        % these constraints enforce t_j + d_j <= t_i over all gates j that drive gate i
+        Aout' * t + Ain' * d <= Ain' * t;
+        
+        % for gates with inputs not connected to other gates we enforce d_i <= t_i
+        d(1:3) <= t(1:3);
+cvx_end

--- a/tests/style/dsl/cvx/128.m
+++ b/tests/style/dsl/cvx/128.m
@@ -1,0 +1,45 @@
+cvx_begin gp quiet
+    % optimization variables
+    variable x(m)           % scale factors
+    
+    % input capacitance is an affine function of sizes
+    cin = alpha + beta .* x;
+    
+    % load capacitance of a gate is the sum of its fan-out c_in's
+    clear cload; % start with a fresh variable
+    cload(1) = cin(4);
+    cload(2) = cin(4) + cin(5);
+    cload(3) = cin(5) + cin(7);
+    cload(4) = cin(6) + cin(7);
+    cload(5) = cin(7);
+    % output gates have their load capacitances
+    cload(6) = Cout6;
+    cload(7) = Cout7;
+    
+    % gate delay is the product of its driving res. R = gamma./x and cload
+    d = (cload') .* gamma ./ x;
+    
+    power = (f .* e)' * x;         % total power
+    area = a' * x;               % total area
+    
+    % evaluate delay over all paths in the given circuit (there are 7 paths)
+    path_delays = [ ...
+    d(1) + d(4) + d(6)  % delay of path 1
+    d(1) + d(4) + d(7)  % delay of path 2, etc...
+    d(2) + d(4) + d(6)
+    d(2) + d(4) + d(7)
+    d(2) + d(5) + d(7)
+    d(3) + d(5) + d(6)
+    d(3) + d(7)];
+    
+    % overall circuit delay
+    circuit_delay = (max(path_delays));
+    
+    % objective is the worst-case delay
+    minimize(circuit_delay)
+    subject to
+        % construct the constraints
+        x >= 1;             % all sizes greater than 1 (normalized)
+        power <= Pmax(n);   % power constraint
+        area <= Amax(k);    % area constraint
+cvx_end

--- a/tests/style/dsl/cvx/129.m
+++ b/tests/style/dsl/cvx/129.m
@@ -1,0 +1,9 @@
+cvx_begin sdp
+    variable w(m,1)   % edge weights
+    variable s        % epigraph variable
+    variable L(n,n) symmetric
+    minimize(s)
+    subject to
+        L == A * diag(w) * A';
+        -s * I <= J - L <= s * I;
+cvx_end

--- a/tests/style/dsl/cvx/130.m
+++ b/tests/style/dsl/cvx/130.m
@@ -1,0 +1,11 @@
+cvx_begin sdp
+    variable w(m,1)   % edge weights
+    variable s        % epigraph variable
+    variable L(n,n) symmetric
+    minimize(s)
+    subject to
+        L == A * diag(w) * A';
+        -s * I <= J - L <= +s * I;
+        w >= 0;
+        diag(L) <= 1;
+cvx_end

--- a/tests/style/dsl/cvx/README.md
+++ b/tests/style/dsl/cvx/README.md
@@ -1,0 +1,6 @@
+# LICENSE
+
+The code snippets in this folder come from the files in CVX's source
+[tarball](http://web.cvxr.com/cvx/cvx-maci64.tar.gz)'s examples folder. The
+original examples are all in public domain, and also available individually
+[here](http://cvxr.com/cvx/examples).


### PR DESCRIPTION
Adds code snippets indented according to CVX's DSL.
Only the relevant CVX blocks are present. The rest of the files' contents were stripped.
The code was extracted from CVX's example folder and reprocessed as follows:
- `mhstyle` was run on the files to make them look nicer.
- The code was then reindented using the rules commonly seen in CVX code.
I did not create nor remove indentation to my liking. The indentation in those files reflects what I've seen in the original files.