### PR TITLE
ENH: Copyright style check recognizes (C) and (c) after Copyright.

### DIFF
--- a/miss_hit_core/config.py
+++ b/miss_hit_core/config.py
@@ -272,7 +272,7 @@ STYLE_RULES = {
             "copyright_regex": Copyright_Regex_Style_Configuration(
                 ("Regex for picking out copyright notice. Must include "
                  "named groups: 'ystart', 'yend', and 'org'"),
-                default = (r"(\(c\) )?Copyright "
+                default = (r"(\([cC]\) )?Copyright (\([cC]\) )?"
                            r"((?P<ystart>\d\d\d\d)(-| - ))?(?P<yend>\d\d\d\d)"
                            r"( by)? *(?P<org>.*)")),
             "copyright_entity": Set_Style_Configuration(

--- a/tests/style/copyright_notices/expected_out.html
+++ b/tests/style/copyright_notices/expected_out.html
@@ -11,6 +11,8 @@
 <div></div>
 <h1>Issues identified</h1>
 <section>
+<h2>inverted_copyright_1.m</h2>
+<div class="message"><a href="matlab:opentoline('inverted_copyright_1.m', 5, 10)">inverted_copyright_1.m: line 5:</a> style: violates naming scheme for function</div>
 <h2>real_world_1.m</h2>
 <div class="message"><a href="matlab:opentoline('real_world_1.m', 1, 10)">real_world_1.m: line 1:</a> style: violates naming scheme for function</div>
 </section>

--- a/tests/style/copyright_notices/expected_out.txt
+++ b/tests/style/copyright_notices/expected_out.txt
@@ -1,8 +1,11 @@
 === PLAIN MODE ===
+In inverted_copyright_1.m, line 5
+| function some_function()
+|          ^^^^^^^^^^^^^ style: violates naming scheme for function
 In real_world_1.m, line 1
 | function initCppSpm()
 |          ^^^^^^^^^^ style: violates naming scheme for function
-MISS_HIT Style Summary: 1 file(s) analysed, 1 style issue(s)
+MISS_HIT Style Summary: 2 file(s) analysed, 2 style issue(s)
 
 === HTML MODE ===
-MISS_HIT Style Summary: 1 file(s) analysed, 1 style issue(s)
+MISS_HIT Style Summary: 2 file(s) analysed, 2 style issue(s)

--- a/tests/style/copyright_notices/inverted_copyright_1.m
+++ b/tests/style/copyright_notices/inverted_copyright_1.m
@@ -1,0 +1,7 @@
+% Copyright (C) 2021 Someone
+
+% This is some function.
+
+function some_function()
+    disp('hello world');
+end

--- a/tests/style/copyright_notices/inverted_copyright_1.m_fixed
+++ b/tests/style/copyright_notices/inverted_copyright_1.m_fixed
@@ -1,0 +1,7 @@
+% Copyright (C) 2021 Someone
+
+% This is some function.
+
+function some_function()
+    disp('hello world');
+end


### PR DESCRIPTION
- `(c)` and `(C)` are both allowed now.
- `(C) Copyright` and `Copyright (C)` are both allowed now.
  - Minor drawback: `(c) Copyright (c)` is also allowed.

This commit implements https://github.com/florianschanda/miss_hit/issues/220 #220 