### PR TITLE
Add --gitlab option to mh_style and mh_lint

### DIFF
--- a/miss_hit/mh_lint.py
+++ b/miss_hit/mh_lint.py
@@ -34,7 +34,8 @@ from miss_hit_core.m_ast import *
 from miss_hit_core.errors import (Error,
                                   Message_Handler,
                                   HTML_Message_Handler,
-                                  JSON_Message_Handler)
+                                  JSON_Message_Handler,
+                                  GITLAB_Message_Handler)
 from miss_hit_core.m_lexer import MATLAB_Lexer
 from miss_hit_core.m_parser import MATLAB_Parser
 from miss_hit_core.m_language_builtins import BUILTIN_FUNCTIONS
@@ -238,6 +239,10 @@ def main_handler():
         "--json",
         default=None,
         help="Produce JSON report")
+    clp["output_options"].add_argument(
+        "--gitlab",
+        default=None,
+        help="Produce gitlab code quality report")
 
     # Extra debug options
     clp["debug_options"].add_argument(
@@ -251,15 +256,25 @@ def main_handler():
     if options.html:
         if options.json:
             clp["ap"].error("Cannot produce JSON and HTML at the same time")
+        if options.gitlab:
+            clp["ap"].error("Cannot produce GITLAB and HTML at the same time")
         if os.path.exists(options.html) and not os.path.isfile(options.html):
             clp["ap"].error("Cannot write to %s: it is not a file" %
                             options.html)
         mh = HTML_Message_Handler("lint", options.html)
     elif options.json:
+        if options.gitlab:
+            clp["ap"].error("Cannot produce JSON and GITLAB at the same time")
         if os.path.exists(options.json) and not os.path.isfile(options.json):
             clp["ap"].error("Cannot write to %s: it is not a file" %
                             options.json)
         mh = JSON_Message_Handler("lint", options.json)
+    elif options.gitlab:
+        if os.path.exists(options.gitlab) \
+                and not os.path.isfile(options.gitlab):
+            clp["ap"].error("Cannot write to %s: it is not a file" %
+                            options.gitlab)
+        mh = GITLAB_Message_Handler("lint", options.gitlab)
     else:
         mh = Message_Handler("lint")
 

--- a/miss_hit_core/errors.py
+++ b/miss_hit_core/errors.py
@@ -28,6 +28,7 @@ import os
 import sys
 import html
 import json
+import hashlib
 
 from miss_hit_core import pathutil
 from miss_hit_core.config import STYLE_RULES, METRICS
@@ -101,6 +102,12 @@ class Location:
             rv["col_end"] = self.col_end
         if detailed and self.context:
             rv["context"] = self.context
+        return rv
+
+    def to_gitlab(self):
+        rv = {}
+        rv["path"] = self.filename if self.filename else ""
+        rv["lines"] = {"begin": self.line if self.line else 0}
         return rv
 
     def short_string(self):
@@ -196,6 +203,36 @@ class Message:
                 "message"   : self.message,
                 "fixable"   : self.fixed,
                 "fatal"     : self.fatal}
+
+    def to_gitlab(self):
+        check_name = self.check_id if self.check_id else ""
+
+        map_severity = {
+            "low": "info",
+            "medium": "minor",
+            "high": "major",
+        }
+        severity = map_severity.get(self.severity, "minor")
+
+        if self.fatal:
+            severity = "critical"
+            check_name = "fatal"
+
+        contents = {
+            "description" : self.message,
+            "check_name"  : check_name,
+            "fingerprint" : 0,
+            "severity"    : severity,
+            "location"    : self.location.to_gitlab(),
+        }
+
+        # Produce unique fingerprint based on contents
+        # Use sort_keys for better reproducibility
+        contents["fingerprint"] = hashlib.sha1(
+            json.dumps(contents, sort_keys=True).encode("utf-8")
+        ).hexdigest()
+
+        return contents
 
 
 class Check_Message(Message):
@@ -753,6 +790,37 @@ class JSON_Message_Handler(File_Based_Message_Handler):
             self.blob[message.location.filename] = []
 
         self.blob[message.location.filename].append(message.to_json())
+
+    def emit_summary(self):
+        self.setup_fd()
+        super().emit_summary()
+        json.dump(self.blob, self.fd, indent=2)
+        self.fd.write("\n")
+        self.fd.close()
+
+
+class GITLAB_Message_Handler(File_Based_Message_Handler):
+    def __init__(self, tool_id, filename):
+        super().__init__(tool_id, filename)
+        self.blob = None
+
+    def fork(self):
+        rv = GITLAB_Message_Handler(self.tool_id, self.filename)
+        self.fork_copy_attributes(rv)
+        return rv
+
+    def setup_fd(self):
+        # pylint: disable=consider-using-with
+        if self.fd is not None:
+            return
+
+        self.fd = open(self.filename, "w", encoding="UTF-8")
+        self.blob = []
+
+    def emit_message(self, message):
+        self.setup_fd()
+
+        self.blob.append(message.to_gitlab())
 
     def emit_summary(self):
         self.setup_fd()

--- a/miss_hit_core/mh_style.py
+++ b/miss_hit_core/mh_style.py
@@ -40,7 +40,8 @@ from miss_hit_core import config
 from miss_hit_core.errors import (Location, Error, ICE,
                                   Message_Handler,
                                   HTML_Message_Handler,
-                                  JSON_Message_Handler)
+                                  JSON_Message_Handler,
+                                  GITLAB_Message_Handler)
 from miss_hit_core.m_ast import *
 from miss_hit_core.m_lexer import MATLAB_Lexer, Token_Buffer
 from miss_hit_core.m_parser import MATLAB_Parser
@@ -1218,6 +1219,10 @@ def main_handler():
         default=None,
         help="Produce JSON report")
     clp["output_options"].add_argument(
+        "--gitlab",
+        default=None,
+        help="Produce gitlab code quality report")
+    clp["output_options"].add_argument(
         "--no-style",
         action="store_true",
         default=False,
@@ -1260,15 +1265,25 @@ def main_handler():
     if options.html:
         if options.json:
             clp["ap"].error("Cannot produce JSON and HTML at the same time")
+        if options.gitlab:
+            clp["ap"].error("Cannot produce GITLAB and HTML at the same time")
         if os.path.exists(options.html) and not os.path.isfile(options.html):
             clp["ap"].error("Cannot write to %s: it is not a file" %
                             options.html)
         mh = HTML_Message_Handler("style", options.html)
     elif options.json:
+        if options.gitlab:
+            clp["ap"].error("Cannot produce JSON and GITLAB at the same time")
         if os.path.exists(options.json) and not os.path.isfile(options.json):
             clp["ap"].error("Cannot write to %s: it is not a file" %
                             options.json)
         mh = JSON_Message_Handler("style", options.json)
+    elif options.gitlab:
+        if os.path.exists(options.gitlab) \
+                and not os.path.isfile(options.gitlab):
+            clp["ap"].error("Cannot write to %s: it is not a file" %
+                            options.gitlab)
+        mh = GITLAB_Message_Handler("style", options.gitlab)
     else:
         mh = Message_Handler("style")
 


### PR DESCRIPTION
This adds a new output format for the `mh_style` and `mh_lint` commands.  
See https://docs.gitlab.com/ci/testing/code_quality/#code-quality-report-format for the specification.

The new code is adapted from the existing JSON handler with different `to_gitlab()` calls, and `self.blob` is a json list instead of an object.

I tested it on gitlab and it seems to work.