### PR TITLE
add no_fix_missing_semicolon config option

### DIFF
--- a/docs/style_checker.html
+++ b/docs/style_checker.html
@@ -149,7 +149,7 @@ foo/external/some_toolkit.m
     <section>
       <h2>Configuration file syntax reference</h2>
       <div>
-        In general the config files follow a simply sytax:
+        In general the config files follow a simply syntax:
         <pre>key: value</pre> The key is some identifier like
         tab_width, and the value is the configuration for that
         key. Integers are written directly, and strings are enclosed
@@ -581,6 +581,8 @@ end
         effectively bans commas and requires semicolons + newline at
         the end of most statements. The exceptions are things like
         'return' or the end of compound statements such as 'if'.
+        Fixing missing semicolons can be disabled with
+        "no_fix_missing_semicolon".
       </div>
 
       <div>

--- a/make.ps1
+++ b/make.ps1
@@ -1,0 +1,70 @@
+[CmdletBinding()]
+param (
+    [switch]$PreCommitChecks,
+    [switch]$Copyright,
+    [switch]$Doc,
+    [switch]$Test,
+    [switch]$Lint,
+    [switch]$Style
+)
+
+
+$AllParams =@($PreCommitChecks, $Copyright, $Doc, $Test, $Lint, $Style)
+
+if ($AllParams -notcontains $true) {
+    $Doc = $true
+    $Test = $true
+    $Lint = $true
+    $Style = $true
+}
+
+if ($Lint) {
+    $Style = $true
+}
+
+if ($PreCommitChecks) {
+    $Copyright = $true
+    $Doc = $true
+    $Test = $true
+    $Lint = $true
+}
+
+$ErrorActionPreference = "Stop"
+
+if ($Copyright) {
+    python hook_scripts\copyright_year.py
+}
+
+if ($Doc) {
+    Push-Location util
+    python update_docs.py
+    python update_versions.py
+    Pop-Location
+}
+
+if ($Test) {
+    Push-Location tests
+    python run.py
+    Pop-Location
+}
+
+if ($Style) {
+    python -m pycodestyle miss_hit_core miss_hit mh_bmc mh_copyright mh_debug_enumerate_simulink_blocks mh_debug_parser mh_diff mh_lint mh_metric mh_sl_unpack mh_style mh_trace
+}
+
+if ($Lint) {
+    python -m pylint --rcfile=pylint3.cfg --reports=no miss_hit_core miss_hit mh_bmc mh_copyright mh_debug_enumerate_simulink_blocks mh_debug_parser mh_diff mh_lint mh_metric mh_sl_unpack mh_style mh_trace
+}
+
+if ($Package) {
+    git clean -xdf
+    Copy-Item -Path setup_gpl.py -Destination setup.py
+    New-Item -Path "miss_hit_core/resources/assets" -ItemType Directory
+    Copy-Item -Path docs/style.css -Destination miss_hit_core/resources
+    Copy-Item -Path docs/assets/* -Destination miss_hit_core/resources/assets
+    python setup.py sdist bdist_wheel
+    Remove-Item -Path "miss_hit_core/resources" -Recurse
+    Copy-Item -Path setup_agpl.py -Destination setup.py
+    python setup.py sdist bdist_wheel
+    Remove-Item -Path setup.py
+}

--- a/miss_hit_core/config.py
+++ b/miss_hit_core/config.py
@@ -356,6 +356,10 @@ STYLE_RULES = {
     "end_of_statements" : Style_Rule(
         "Ensures consistent ending of statements."),
 
+    "no_fix_missing_semicolon" : Style_Rule(
+        "Allows statement to not end in a semicolon if"
+        " 'end_of_statements' is enabled."),
+
     "builtin_shadow" : Style_Rule(
         "Checks that assignments do not overwrite builtin functions such as"
         " true, false, or pi."),

--- a/miss_hit_core/m_parser.py
+++ b/miss_hit_core/m_parser.py
@@ -439,11 +439,12 @@ class MATLAB_Parser:
 
             else:
                 assert terminator_tokens[0].kind == "NEWLINE"
-                self.mh.style_issue(ending_token.location,
-                                    "end statement with a semicolon",
-                                    "end_of_statements",
-                                    True)
-                ending_token.fix.add_semicolon_after = True
+                if not self.cfg.active("no_fix_missing_semicolon"):
+                    self.mh.style_issue(ending_token.location,
+                                        "end statement with a semicolon",
+                                        "end_of_statements",
+                                        True)
+                    ending_token.fix.add_semicolon_after = True
 
             if first_newline is None:
                 fixed = False

--- a/tests/style/no_fix_missing_semicolon/expected_out.html
+++ b/tests/style/no_fix_missing_semicolon/expected_out.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<link rel="stylesheet" href="file:../../../docs/style.css">
+<title>MISS_HIT Report</title>
+</head>
+<body>
+<header>MISS_HIT Report</header>
+<main>
+<div></div>
+<h1>Issues identified</h1>
+<section>
+<h2>test.m</h2>
+<div class="message"><a href="matlab:opentoline('test.m')">test.m:</a> style: violates naming scheme for scripts</div>
+<div class="message"><a href="matlab:opentoline('test.m', 5, 8)">test.m: line 5:</a> style: end this with a semicolon instead of a comma</div>
+<div class="message"><a href="matlab:opentoline('test.m', 5, 8)">test.m: line 5:</a> style: end statement with a newline</div>
+<div class="message"><a href="matlab:opentoline('test.m', 8, 8)">test.m: line 8:</a> style: end this with a semicolon instead of a comma</div>
+<div class="message"><a href="matlab:opentoline('test.m', 8, 8)">test.m: line 8:</a> style: end statement with a newline</div>
+</section>
+</main>
+</body>
+</html>

--- a/tests/style/no_fix_missing_semicolon/expected_out.txt
+++ b/tests/style/no_fix_missing_semicolon/expected_out.txt
@@ -1,0 +1,18 @@
+=== PLAIN MODE ===
+test.m: style: violates naming scheme for scripts [naming_scripts]
+In test.m, line 5
+| baz = 4, bar = 5;
+|        ^ style: end this with a semicolon instead of a comma [fixed] [end_of_statements]
+In test.m, line 5
+| baz = 4, bar = 5;
+|        ^ style: end statement with a newline [fixed] [end_of_statements]
+In test.m, line 9
+| bas = 5, foo = 9
+|        ^ style: end this with a semicolon instead of a comma [fixed] [end_of_statements]
+In test.m, line 9
+| bas = 5, foo = 9
+|        ^ style: end statement with a newline [fixed] [end_of_statements]
+MISS_HIT Style Summary: 1 file(s) analysed, 5 style issue(s)
+
+=== HTML MODE ===
+MISS_HIT Style Summary: 1 file(s) analysed, 5 style issue(s)

--- a/tests/style/no_fix_missing_semicolon/miss_hit.cfg
+++ b/tests/style/no_fix_missing_semicolon/miss_hit.cfg
@@ -1,0 +1,1 @@
+enable_rule: "no_fix_missing_semicolon"

--- a/tests/style/no_fix_missing_semicolon/test.m
+++ b/tests/style/no_fix_missing_semicolon/test.m
@@ -1,0 +1,8 @@
+% (c) Copyright 2019 Zenuity AB
+
+% Should end in semicolons
+foo = 1;
+baz = 4, bar = 5;
+% foo and spoon should reamin without a semicolon
+spoon
+bas = 5, foo = 9

--- a/tests/style/no_fix_missing_semicolon/test.m_fixed
+++ b/tests/style/no_fix_missing_semicolon/test.m_fixed
@@ -1,0 +1,10 @@
+% (c) Copyright 2019 Zenuity AB
+
+% Should end in semicolons
+foo = 1;
+baz = 4;
+bar = 5;
+% foo and spoon should reamin without a semicolon
+spoon
+bas = 5;
+foo = 9


### PR DESCRIPTION
As described in #305, this simply adds an option to allow the user to have lines not terminated with semicolons. Also a typo fix snuck in.